### PR TITLE
fix `matches` regex

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "LeetCode Fix",
-    "description": "Leetcode extension for showing the programming language beside submissions.",
+    "description": "Leetcode extension for showing dislike count in Dynamic Layout.",
     "author": "https://github.com/bunnykek",
     "version": "0.0.3",
     "icons": {
@@ -18,7 +18,7 @@
                 "content.js"
             ],
             "matches": [
-                "https://leetcode.com/problems/*/description/"
+                "https://leetcode.com/problems/*/description/*"
             ]
         }
     ]


### PR DESCRIPTION
fix regex to ignore query params (if any).
e.g., `?envType=daily-question&envId=2023-11-06` which comes up when clicked on the streak icon in top right.