### PR TITLE
Overhaul: Show full likes counter, bug fixes, performance improvements

### DIFF
--- a/content.js
+++ b/content.js
@@ -81,13 +81,13 @@ function waitForElementToExist(selector) {
     return new Promise(resolve => {
         let element = document.querySelector(selector);
         if (element) {
-            return resolve(element)
-        };
+            return resolve(element);
+        }
         const observer = new MutationObserver(() => {
             element = document.querySelector(selector);
             if (element) {
-                resolve(element);
                 observer.disconnect();
+                resolve(element);
             }
         });
         observer.observe(document.body, { childList: true, subtree: true });
@@ -97,7 +97,7 @@ function waitForElementToExist(selector) {
 function waitForInnerHTMLChange(element, initialValue) {
     return new Promise(resolve => {
         if (element.innerHTML != initialValue) {
-            resolve();
+            return resolve();
         }
         const observer = new MutationObserver(() => {
             if (element.innerHTML != initialValue) {

--- a/content.js
+++ b/content.js
@@ -4,16 +4,19 @@ const EMPTY_DIV = `<div></div>`;
 const THUMBS_UP_SELECTOR = '[data-icon="thumbs-up"]';
 const THUMBS_DOWN_SELECTOR = '[data-icon="thumbs-down"]';
 
-function handleThumbsDownClick(event) {
-    const thumbsDownButton = event.srcElement.closest('button');
-    const toggled = thumbsDownButton.firstElementChild.firstElementChild.getAttribute('data-prefix') == 'far';
-    const numDislikes = thumbsDownButton.lastElementChild.innerHTML;
-    thumbsDownButton.lastElementChild.innerHTML = parseInt(numDislikes) + (toggled ? 1 : -1);
+function handleThumbsClick(event) {
+    const thumbsButton = event.srcElement.closest('button');
+    const toggled = thumbsButton.firstElementChild.firstElementChild.getAttribute('data-prefix') == 'far';
+    const count = thumbsButton.lastElementChild.innerHTML;
+    thumbsButton.lastElementChild.innerHTML = parseInt(count) + (toggled ? 1 : -1);
 }
 
-async function manipulate() {
+function getProblemId() {
     const url = window.location.href;
-    const problemId = url.match(/https:\/\/leetcode\.com\/problems\/([a-z0-9\-]+)/)[1];
+    return url.match(/https:\/\/leetcode\.com\/problems\/([a-z0-9\-]+)/)[1];
+}
+
+async function getLikesAndDislikes(problemId) {
     const query = `
       query questionData($titleSlug: String!) {
         question(titleSlug: $titleSlug) {
@@ -32,56 +35,78 @@ async function manipulate() {
         })
     });
     const jresp = await response.json();
-    const num_likes = jresp['data']['question']['likes'];
-    const num_dislikes = jresp['data']['question']['dislikes'];
-    console.log("likes", num_likes);
-    console.log("dislikes", num_dislikes);
+    return {
+        'likes': jresp['data']['question']['likes'],
+        'dislikes': jresp['data']['question']['dislikes']
+    };
+}
 
-    const thumbsUpButton = document.querySelector(THUMBS_UP_SELECTOR).closest('button');
-    const thumbsDownButton = document.querySelector(THUMBS_DOWN_SELECTOR).closest('button');
-    thumbsDownButton.lastElementChild.insertAdjacentHTML('afterend', EMPTY_DIV);
-    thumbsUpButton.lastElementChild.innerHTML = num_likes;
-    thumbsDownButton.lastElementChild.innerHTML = num_dislikes;
-    thumbsDownButton.addEventListener('click', handleThumbsDownClick);
+function manipulateDislikes(thumbsUpButton, thumbsDownButton, dislikes) {
+    // Add div and click handler if needed
+    if (thumbsDownButton.childElementCount == 1) {
+        thumbsDownButton.lastElementChild.insertAdjacentHTML('afterend', EMPTY_DIV);
+        thumbsDownButton.addEventListener('click', handleThumbsClick);
+        // Copy css from like button to dislike button
+        thumbsDownButton.classList = thumbsUpButton.classList;
+    }
 
-    // Copy css from like button to dislike button
-    thumbsDownButton.classList = thumbsUpButton.classList;
+    // Update count
+    thumbsDownButton.lastElementChild.innerHTML = dislikes;
+}
+
+function manipulateLikes(thumbsUpButton, newLikes) {
+    // Replace truncated like count with the full like count
+    const updateLikesInterval = setInterval(() => {
+        const oldLikes = thumbsUpButton.lastElementChild.innerHTML;
+        if (oldLikes.includes('.') || oldLikes.endsWith('K')) {
+            thumbsUpButton.lastElementChild.innerHTML = newLikes;
+            if (!manipulateLikes.listenerAdded) {
+                thumbsUpButton.addEventListener('click', handleThumbsClick);
+                manipulateLikes.listenerAdded = true;
+            }
+            clearInterval(updateLikesInterval);
+        }
+    }, 200);
+    // Stop trying after 3s
+    setTimeout(() => {
+        clearInterval(updateLikesInterval);
+    }, 3000);
 }
 
 function waitForElm(selector) {
     return new Promise(resolve => {
-        if (document.querySelector(selector)) {
-            return resolve(document.querySelector(selector));
-        }
+        let element = document.querySelector(selector);
+        if (element) {
+            return resolve(element)
+        };
 
-        const observer = new MutationObserver(mutations => {
-            if (document.querySelector(selector)) {
-                resolve(document.querySelector(selector));
+        const observer = new MutationObserver(() => {
+            element = document.querySelector(selector);
+            if (element) {
+                resolve(element);
                 observer.disconnect();
             }
         });
 
-        observer.observe(document.body, {
-            childList: true,
-            subtree: true
-        });
+        observer.observe(document.body, { childList: true, subtree: true });
     });
 }
 
-waitForElm(THUMBS_DOWN_SELECTOR).then((elm) => {
-    console.log('Page reloaded');
-    manipulate();
-});
-
-let lastUrl = location.href;
-new MutationObserver(() => {
-    const url = location.href;
-    const match = url.match(/https:\/\/leetcode\.com\/problems\/([a-z0-9\-]+)/);
-    if (!lastUrl.includes(match[1])) {
-        lastUrl = url;
-        waitForElm(THUMBS_DOWN_SELECTOR).then((elm) => {
-            console.log('Element is ready');
-            manipulate();
-        });
+let prevProblemId;
+new MutationObserver(async () => {
+    const problemId = getProblemId();
+    if (problemId != prevProblemId) {
+        prevProblemId = problemId;
+        const { likes, dislikes } = await getLikesAndDislikes(problemId);
+        console.log(likes);
+        console.log(dislikes);
+        waitForElm(THUMBS_DOWN_SELECTOR).then(
+            thumbsDownIcon => {
+                const thumbsUpButton = document.querySelector(THUMBS_UP_SELECTOR).closest('button');
+                const thumbsDownButton = thumbsDownIcon.closest('button')
+                manipulateLikes(thumbsUpButton, likes);
+                manipulateDislikes(thumbsUpButton, thumbsDownButton, dislikes);
+            }
+        );
     }
 }).observe(document, { subtree: true, childList: true });

--- a/content.js
+++ b/content.js
@@ -69,11 +69,12 @@ function manipulateDislikes(thumbsUpButton, thumbsDownButton, dislikes) {
     thumbsDownButton.lastElementChild.innerHTML = dislikes;
 }
 
+let thumbsUpListenerAdded = false;
 function manipulateLikes(thumbsUpButton, newLikes) {
     thumbsUpButton.lastElementChild.innerHTML = newLikes;
-    if (!manipulateLikes.listenerAdded) {
+    if (!thumbsUpListenerAdded) {
         thumbsUpButton.addEventListener('click', handleThumbsClick);
-        manipulateLikes.listenerAdded = true;
+        thumbsUpListenerAdded = true;
     }
 }
 
@@ -87,9 +88,11 @@ function waitForElementToExist(selector) {
             element = document.querySelector(selector);
             if (element) {
                 observer.disconnect();
+                clearTimeout(observerTimeout);
                 resolve(element);
             }
         });
+        const observerTimeout = setTimeout(() => observer.disconnect(), 5000);
         observer.observe(document.body, { childList: true, subtree: true });
     });
 }
@@ -102,9 +105,11 @@ function waitForInnerHTMLChange(element, initialValue) {
         const observer = new MutationObserver(() => {
             if (element.innerHTML != initialValue) {
                 observer.disconnect();
+                clearTimeout(observerTimeout);
                 resolve();
             }
         });
+        const observerTimeout = setTimeout(() => observer.disconnect(), 5000);
         observer.observe(element, { childList: true, subtree: true, characterData: true });
     });
 }

--- a/content.js
+++ b/content.js
@@ -1,8 +1,15 @@
 //by @bunnykek or lc: bunny404
 
-const DISLIKE_ELE = `<div class="dislike_count"></div>`;
+const EMPTY_DIV = `<div></div>`;
 const THUMBS_UP_SELECTOR = '[data-icon="thumbs-up"]';
 const THUMBS_DOWN_SELECTOR = '[data-icon="thumbs-down"]';
+
+function handleThumbsDownClick(event) {
+    const thumbsDownButton = event.srcElement.closest('button');
+    const toggled = thumbsDownButton.firstElementChild.firstElementChild.getAttribute('data-prefix') == 'far';
+    const numDislikes = thumbsDownButton.lastElementChild.innerHTML;
+    thumbsDownButton.lastElementChild.innerHTML = parseInt(numDislikes) + (toggled ? 1 : -1);
+}
 
 async function manipulate() {
     const url = window.location.href;
@@ -30,13 +37,14 @@ async function manipulate() {
     console.log("likes", num_likes);
     console.log("dislikes", num_dislikes);
 
-    const thumbsUpButton = document.querySelector(THUMBS_UP_SELECTOR)?.closest('button');
-    const thumbsDownButton = document.querySelector(THUMBS_DOWN_SELECTOR)?.closest('button');
-    thumbsDownButton.insertAdjacentHTML('afterend', DISLIKE_ELE);
-    thumbsDownButton.parentElement.addEventListener('click', dislikeHandler);
-
+    const thumbsUpButton = document.querySelector(THUMBS_UP_SELECTOR).closest('button');
+    const thumbsDownButton = document.querySelector(THUMBS_DOWN_SELECTOR).closest('button');
+    thumbsDownButton.lastElementChild.insertAdjacentHTML('afterend', EMPTY_DIV);
     thumbsUpButton.lastElementChild.innerHTML = num_likes;
     thumbsDownButton.lastElementChild.innerHTML = num_dislikes;
+    thumbsDownButton.addEventListener('click', handleThumbsDownClick);
+
+    // Copy css from like button to dislike button
     thumbsDownButton.classList = thumbsUpButton.classList;
 }
 
@@ -60,20 +68,8 @@ function waitForElm(selector) {
     });
 }
 
-let toggled = false;
-function dislikeHandler() {
-    toggled = !toggled;
-    const dislike_count = document.getElementsByClassName("dislike_count")[0]?.innerHTML;
-    if (dislike_count) {
-        document.getElementsByClassName("dislike_count")[0].innerHTML = parseInt(dislike_count) + (toggled ? 1 : -1);
-    }
-}
-
 waitForElm(THUMBS_DOWN_SELECTOR).then((elm) => {
     console.log('Page reloaded');
-    const selector = document.querySelector(THUMBS_DOWN_SELECTOR).parentElement;
-    selector.insertAdjacentHTML('afterend', DISLIKE_ELE);
-    selector.parentElement.addEventListener('click', dislikeHandler);
     manipulate();
 });
 


### PR DESCRIPTION
Correctly handle page transitions (from problemset -> problem and problem -> problem). Previous implementation was unreliable.
Show the exact no. of likes (e.g., show 1521 instead of 1.5K)
Remove/minimize update delay
Cache api calls using localStorage with 1 day expiry
Fix edge case: user dislikes the problem and refreshes the page. Clicking the dislike button again should decrement the counter instead of incrementing.
Improve overall performance and code quality